### PR TITLE
Use hashbrown instead of std::collections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symoxide"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Kaushik Kulkarni <kaushikcfd@gmail.com>"]
 edition = "2021"
 description = "Intermediate Representation and Transformations for Computer Algebra Systems"
@@ -24,3 +24,4 @@ log = "0.4.17"
 symoxide_macros = "0.1.0"
 pytools-rs = "0.1.1"
 regex = "1.6.0"
+hashbrown = "0.12.3"

--- a/examples/ex_large_expr.rs
+++ b/examples/ex_large_expr.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use hashbrown::HashMap;
 use std::rc::Rc;
 use symoxide as sym;
 use symoxide::mappers::identity::IdentityMapper;

--- a/examples/ex_mapper.rs
+++ b/examples/ex_mapper.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use hashbrown::HashMap;
 use std::rc::Rc;
 use symoxide::mappers::identity::IdentityMapper;
 use symoxide::mappers::CachedMapper;

--- a/src/mapper_impls/deduplicator.rs
+++ b/src/mapper_impls/deduplicator.rs
@@ -22,7 +22,7 @@ use crate::mapper_impls::hasher::{get_hasher, HashCacher};
 use crate::mappers::identity::IdentityMapperWithCustomCacheKey;
 use crate::mappers::CachedMapper;
 use crate::{CachedMapper, Expression};
-use std::collections::HashMap;
+use hashbrown::HashMap;
 use std::hash::{Hash, Hasher};
 use std::rc::Rc;
 

--- a/src/mapper_impls/equality.rs
+++ b/src/mapper_impls/equality.rs
@@ -20,7 +20,7 @@
 
 use crate::primitives::{BinaryOpType, Expression, LiteralT, UnaryOpType};
 use crate::utils::ExpressionRawPointer;
-use std::collections::HashMap;
+use hashbrown::HashMap;
 use std::rc::Rc;
 
 struct EqualityMapper {

--- a/src/mapper_impls/graphvizifier.rs
+++ b/src/mapper_impls/graphvizifier.rs
@@ -23,10 +23,10 @@ use crate::mappers::CachedMapper;
 use crate::primitives::{BinaryOpType, Expression, LiteralT, UnaryOpType};
 use crate::utils::ExpressionRawPointer;
 use crate::CachedMapper;
+use hashbrown::HashMap;
 use pytools_rs::{
     make_unique_name_gen, show_dot as show_dot_code, ConvertibleToDotOutputT, UniqueNameGenerator,
 };
-use std::collections::HashMap;
 use std::rc::Rc;
 
 #[derive(CachedMapper)]

--- a/src/mapper_impls/hasher.rs
+++ b/src/mapper_impls/hasher.rs
@@ -3,8 +3,8 @@ use crate::mappers::CachedMapper;
 use crate::primitives::{BinaryOpType, Expression, LiteralT, UnaryOpType};
 use crate::utils::ExpressionRawPointer;
 use crate::CachedMapper;
+use hashbrown::HashMap;
 use std::collections::hash_map::DefaultHasher;
-use std::collections::HashMap;
 use std::hash::Hasher;
 use std::rc::Rc;
 

--- a/src/mapper_impls/node_counter.rs
+++ b/src/mapper_impls/node_counter.rs
@@ -23,7 +23,7 @@ use crate::mappers::CachedMapper;
 use crate::primitives::Expression;
 use crate::utils::ExpressionRawPointer;
 use crate::CachedMapper;
-use std::collections::HashMap;
+use hashbrown::HashMap;
 use std::rc::Rc;
 
 #[derive(CachedMapper)]

--- a/src/mapper_impls/reprifier.rs
+++ b/src/mapper_impls/reprifier.rs
@@ -3,7 +3,7 @@ use crate::mappers::CachedMapper;
 use crate::primitives::{BinaryOpType, Expression, LiteralT, UnaryOpType};
 use crate::utils::ExpressionRawPointer;
 use crate::CachedMapper;
-use std::collections::HashMap;
+use hashbrown::HashMap;
 use std::fmt;
 use std::rc::Rc;
 

--- a/src/mapper_impls/stringifier.rs
+++ b/src/mapper_impls/stringifier.rs
@@ -3,7 +3,7 @@ use crate::mappers::CachedMapper;
 use crate::primitives::{BinaryOpType, Expression, LiteralT, UnaryOpType};
 use crate::utils::ExpressionRawPointer;
 use crate::CachedMapper;
-use std::collections::HashMap;
+use hashbrown::HashMap;
 use std::fmt;
 use std::rc::Rc;
 


### PR DESCRIPTION
It gets us around 1.43x speedup after using https://github.com/rust-lang/hashbrown.

```
[line@line symoxide]$ git checkout main  -q
[line@line symoxide]$ cargo run --example ex_large_expr --release
   Compiling symoxide v0.1.0 (/home/line/projects/symoxide)
    Finished release [optimized] target(s) in 2.10s
     Running `target/release/examples/ex_large_expr`
Took: 365.337552ms
[line@line symoxide]$ git checkout hashbrown 
Switched to branch 'hashbrown'
[line@line symoxide]$ cargo run --example ex_large_expr --release
   Compiling symoxide v0.1.1 (/home/line/projects/symoxide)
    Finished release [optimized] target(s) in 2.13s
     Running `target/release/examples/ex_large_expr`
Took: 254.625819ms
```